### PR TITLE
Ability to stop DoDHT()

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -101,7 +101,7 @@ type DHT struct {
 
 	// Public channels:
 	PeersRequestResults chan map[InfoHash][]string // key = infohash, v = slice of peers.
-    StopDHT chan bool
+	StopDHT             chan bool
 }
 
 func NewDHTNode(port, numTargetPeers int, storeEnabled bool) (node *DHT, err error) {
@@ -110,6 +110,7 @@ func NewDHTNode(port, numTargetPeers int, storeEnabled bool) (node *DHT, err err
 		routingTable:         newRoutingTable(),
 		peerStore:            newPeerStore(),
 		PeersRequestResults:  make(chan map[InfoHash][]string, 1),
+		StopDHT:              make(chan bool),
 		exploredNeighborhood: false,
 		// Buffer to avoid blocking on sends.
 		remoteNodeAcquaintance: make(chan string, 100),
@@ -262,8 +263,8 @@ func (d *DHT) DoDHT() {
 M:
 	for {
 		select {
-        case _ = <-d.StopDHT:
-            break M
+		case _ = <-d.StopDHT:
+			break M
 		case addr := <-d.remoteNodeAcquaintance:
 			d.helloFromPeer(addr)
 		case req := <-d.peersRequest:


### PR DESCRIPTION
I am writing tests for an application that uses the DHT and I need to be able to stop a `go d.DoDHT()` for test isolation teardown.
