### PR TITLE
Optional CLI flags

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -7,5 +7,5 @@ func (d *DHT) DoDHT() {
 
 // NewDHTNode has been deprecated. Please use New instead.
 func NewDHTNode(port, numTargetPeers int, storeEnabled bool) (node *DHT, err error) {
-	return New(port, numTargetPeers, storeEnabled)
+	return New(port, numTargetPeers, storeEnabled, nil)
 }

--- a/dht_test.go
+++ b/dht_test.go
@@ -2,6 +2,7 @@ package dht
 
 import (
 	"expvar"
+	"flag"
 	"fmt"
 	"math/rand"
 	"net"
@@ -20,7 +21,7 @@ func ExampleDHT() {
 		fmt.Println("Peer found for the requested infohash or the test was skipped")
 		return
 	}
-	d, err := New(0, 100, false)
+	d, err := New(0, 100, false, nil)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -69,7 +70,7 @@ M:
 }
 
 func startDHTNode(t *testing.T) *DHT {
-	node, err := New(0, 100, false)
+	node, err := New(0, 100, false, nil)
 	node.nodeId = string(randNodeId())
 	if err != nil {
 		t.Errorf("New(): %v", err)
@@ -151,6 +152,43 @@ func TestDHTLarge(t *testing.T) {
 		for _, peer := range peers {
 			t.Logf("peer found: %v", nettools.BinaryToDottedPort(peer))
 		}
+	}
+}
+
+func TestNewDHTConfig(t *testing.T) {
+	c := NewDefaultConfig()
+	d, err := New(6060, 10, false, c)
+	if err != nil {
+		t.Fatalf("DHT failed to init with config: %v", err)
+	}
+	if d.config != c {
+		t.Fatal("DHT not initialized with config")
+	}
+}
+
+func TestRegisterFlags(t *testing.T) {
+	c := &Config{
+		DHTRouters:    "example.router.com:6060",
+		MaxNodes:      2020,
+		CleanupPeriod: time.Second,
+		SavePeriod:    time.Second * 2,
+		RateLimit:     999,
+	}
+	RegisterFlags(c)
+	if flag.Lookup("routers").DefValue != c.DHTRouters {
+		t.Fatal("Incorrect routers flag")
+	}
+	if flag.Lookup("maxNodes").DefValue != strconv.FormatInt(int64(c.MaxNodes), 10) {
+		t.Fatal("Incorrect maxNodes flag")
+	}
+	if flag.Lookup("cleanupPeriod").DefValue != c.CleanupPeriod.String() {
+		t.Fatal("Incorrect cleanupPeriod flag")
+	}
+	if flag.Lookup("savePeriod").DefValue != c.SavePeriod.String() {
+		t.Fatal("Incorrect routers flag")
+	}
+	if flag.Lookup("rateLimit").DefValue != strconv.FormatInt(c.RateLimit, 10) {
+		t.Fatal("Incorrect routers flag")
 	}
 }
 

--- a/routing_table.go
+++ b/routing_table.go
@@ -184,7 +184,7 @@ func (r *routingTable) resetNeighborhoodBoundary() {
 
 }
 
-func (r *routingTable) cleanup() (needPing []*remoteNode) {
+func (r *routingTable) cleanup(cleanupPeriod time.Duration) (needPing []*remoteNode) {
 	needPing = make([]*remoteNode, 0, 10)
 	t0 := time.Now()
 	// Needs some serious optimization.

--- a/routing_test.go
+++ b/routing_test.go
@@ -43,7 +43,7 @@ func BenchmarkInsertRecursive(b *testing.B) {
 
 func BenchmarkFindClosest(b *testing.B) {
 	b.StopTimer()
-	node, err := New(0, 1e7, false)
+	node, err := New(0, 1e7, false, nil)
 	node.nodeId = "00bcdefghij01234567"
 	if err != nil {
 		b.Fatal(err)


### PR DESCRIPTION
The automatically registered flags clutter and possibly conflict with applications using this package.  They also don't necessarily match the wrapping application's argument style (i.e. two-words vs twoWords).

This patch also enables configuration by the wrapping application, previously configuration could only be done by the person running the binary.
