### PR TITLE
Allow address to be chosen

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -45,6 +45,8 @@ import (
 
 // DHT Node configuration
 type Config struct {
+	// IP Address to listen on.  If left blank, one is chosen automatically.
+	Address string
 	// UDP port the DHT node should listen on. If zero, it picks a random port.
 	Port int
 	// Number of peers that DHT will try to find for each infohash being searched. This might
@@ -68,6 +70,7 @@ type Config struct {
 // Creates a *Config populated with default values.
 func NewConfig() *Config {
 	return &Config{
+		Address:          "",
 		Port:             0, // Picks a random port.
 		NumTargetPeers:   5,
 		DHTRouters:       "1.a.magnets.im:6881,router.utorrent.com:6881",
@@ -265,7 +268,7 @@ func (d *DHT) findNode(id string) {
 // listens for incoming DHT requests.
 func (d *DHT) Run() error {
 	socketChan := make(chan packetType)
-	socket, err := listen(d.config.Port)
+	socket, err := listen(d.config.Address, d.config.Port)
 	if err != nil {
 		return err
 	}

--- a/krpc.go
+++ b/krpc.go
@@ -196,9 +196,9 @@ type packetType struct {
 	raddr *net.UDPAddr
 }
 
-func listen(listenPort int) (socket *net.UDPConn, err error) {
+func listen(addr string, listenPort int) (socket *net.UDPConn, err error) {
 	// debug.Printf("DHT: Listening for peers on port: %d\n", listenPort)
-	listener, err := net.ListenPacket("udp4", ":"+strconv.Itoa(listenPort))
+	listener, err := net.ListenPacket("udp4", addr+":"+strconv.Itoa(listenPort))
 	if err != nil {
 		// debug.Println("DHT: Listen failed:", err)
 	}


### PR DESCRIPTION
`Address` is added to `Config` and used in `listen()` to allow choice of interface.  Doesn't break the API, should be safe
