### PR TITLE
close listener on exit

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -293,6 +293,7 @@ func (d *DHT) Run() error {
 		return err
 	}
 	d.conn = socket
+	defer d.conn.Close()
 
 	// Update the stored port number in case it was set 0, meaning it was
 	// set automatically by the system


### PR DESCRIPTION
mostly harmless, except on some special test-cases where config.Port is fixed (not 0) and dht runs more than once on the same port