### PR TITLE
push down more peers to the client

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -802,9 +802,10 @@ func (d *DHT) processGetPeerResults(node *remoteNode, resp responseType) {
 	if resp.R.Values != nil {
 		peers := make([]string, 0)
 		for _, peerContact := range resp.R.Values {
-			if ok := d.peerStore.addContact(query.ih, peerContact); ok {
-				peers = append(peers, peerContact)
-			}
+			// send peer even if we already have it in store
+			// the underlying client does/should handle dupes
+			d.peerStore.addContact(query.ih, peerContact)
+			peers = append(peers, peerContact)
 		}
 		if len(peers) > 0 {
 			// Finally, new peers.

--- a/dht.go
+++ b/dht.go
@@ -685,6 +685,9 @@ func (d *DHT) replyAnnouncePeer(addr net.UDPAddr, node *remoteNode, r responseTy
 		// it has an infohash. Enables faster upgrade of other nodes to
 		// "peer" of an infohash, if the announcement is valid.
 		node.lastResponseTime = time.Now().Add(-searchRetryPeriod)
+		if d.peerStore.hasLocalDownload(ih) {
+			d.PeersRequestResults <- map[InfoHash][]string{ih: []string{nettools.DottedPortToBinary(peerAddr.String())}}
+		}
 	}
 	// Always reply positively. jech says this is to avoid "back-tracking", not sure what that means.
 	reply := replyMessage{


### PR DESCRIPTION
after a lengthy debugging session, we came up with 2 fixes regarding what peers go down to the `PeerRequestResult` pipe  

Context: we are running tests using a wip modded-taipei, no tracker, and had trouble making a local swarm behave correctly. `cfg.DhtRouter` is set to the seed with N leeches bootstrapping on it. There was some kind of race between `announce_peer` and `get_peers`. If a dht node N1 receives an announce from N2 on a torrent, it adds N2 to the `peerStore`. After that if a `get_peers` query returns to N1 with a peers list containing N2, it fails to add it to the local peer store (it's already there), then drops the N2 address, resulting in N1 and N2 never connecting to each other. The use case is somewhat specific since there is no routing table initially and only 1 DhtRouter bootstrapping the network, making the issue worse with fewer peers (no connections whatsoever to the seed/bootstrap with N<8 leeches, even though they correctly connect to each other) 

* ae18433 : even though peers are already in store, pass them down to the client who will decide what to do with it
* ac2790e : push an extra available peer in response to an announce on a torrent we already announced previously (hasLocalDownload)
