### PR TITLE
voluntarily run dht in a go routine

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -304,6 +304,7 @@ func (d *DHT) Start() (err error) {
 // If initSocket succeeds, Run blocks until d.Stop() is called.
 // DEPRECATED - Start should be used instead of Run
 func (d *DHT) Run() error {
+	log.Warning("dht.Run() is deprecated, use dht.Start() instead")
 	if err := d.initSocket(); err != nil {
 		return err
 	}

--- a/dht.go
+++ b/dht.go
@@ -284,20 +284,54 @@ func (d *DHT) findNode(id string) {
 	}
 }
 
-// Run starts a DHT node. It bootstraps a routing table, if necessary, and
-// listens for incoming DHT requests.
+// Start launches the dht node. It starts a listener
+// on the desired address, then runs the main loop in a
+// separate go routine - Start replaces Run and will
+// always return, with nil if the dht successfully
+// started or with an error either. d.Stop() is expected
+// by the caller to stop the dht
+func (d *DHT) Start() (err error) {
+	if err = d.initSocket(); err == nil {
+		go d.loop()
+	}
+	return err
+}
+
+// Run launches the dht node. It starts a listener
+// on the desired address, then runs the main loop in the
+// same go routine.
+// If initSocket fails, Run returns with the error.
+// If initSocket succeeds, Run blocks until d.Stop() is called.
+// DEPRECATED - Start should be used instead of Run
 func (d *DHT) Run() error {
-	socketChan := make(chan packetType)
-	socket, err := listen(d.config.Address, d.config.Port, d.config.UDPProto)
+	if err := d.initSocket(); err != nil {
+		return err
+	}
+	d.loop()
+	return nil
+}
+
+// initSocket initializes the udp socket
+// listening to incoming dht requests
+func (d *DHT) initSocket() (err error) {
+	d.conn, err = listen(d.config.Address, d.config.Port, d.config.UDPProto)
 	if err != nil {
 		return err
 	}
-	d.conn = socket
-	defer d.conn.Close()
 
 	// Update the stored port number in case it was set 0, meaning it was
 	// set automatically by the system
-	d.config.Port = socket.LocalAddr().(*net.UDPAddr).Port
+	d.config.Port = d.conn.LocalAddr().(*net.UDPAddr).Port
+	return nil
+}
+
+// loop is the main working section of dht.
+// It bootstraps a routing table, if necessary,
+// and listens for incoming DHT requests until d.Stop()
+// is called from another go routine.
+func (d *DHT) loop() {
+	// Close socket
+	defer d.conn.Close()
 
 	// There is goroutine pushing and one popping items out of the arena.
 	// One passes work to the other. So there is little contention in the
@@ -305,7 +339,8 @@ func (d *DHT) Run() error {
 	// readFromSocket or the packet processing ever need to be
 	// parallelized, this would have to be bumped.
 	bytesArena := newArena(maxUDPPacketSize, 3)
-	go readFromSocket(socket, socketChan, bytesArena, d.stop)
+	socketChan := make(chan packetType)
+	go readFromSocket(d.conn, socketChan, bytesArena, d.stop)
 
 	// Bootstrap the network (only if there are configured dht routers).
 	if d.config.DHTRouters != "" {
@@ -343,7 +378,7 @@ func (d *DHT) Run() error {
 			log.V(1).Infof("DHT exiting.")
 			d.clientThrottle.Stop()
 			log.Flush()
-			return nil
+			return
 		case addr := <-d.remoteNodeAcquaintance:
 			d.helloFromPeer(addr)
 		case req := <-d.peersRequest:

--- a/dht_test.go
+++ b/dht_test.go
@@ -32,7 +32,10 @@ func ExampleDHT() {
 		fmt.Println(err)
 		return
 	}
-	go d.Run()
+	if err = d.Start(); err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	infoHash, err := DecodeInfoHash("d1c5676ae7ac98e8b19f63565905105e3c4c37a2")
 	if err != nil {
@@ -86,7 +89,9 @@ func startNode(routers string, ih string) (*DHT, error) {
 	}
 	// Remove the buffer
 	node.peersRequest = make(chan ihReq, 0)
-	go node.Run()
+	if err = node.Start(); err != nil {
+		return nil, err
+	}
 	node.PeersRequest(ih, true)
 	return node, nil
 }
@@ -175,7 +180,9 @@ func TestDHTLarge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dht New: %v", err)
 	}
-	go node.Run()
+	if err = node.Start(); err != nil {
+		t.Fatalf("node.Run: %v", err)
+	}
 	realDHTNodes := []string{
 		"1.a.magnets.im",
 		"router.utorrent.com",

--- a/examples/find_infohash_and_wait/main.go
+++ b/examples/find_infohash_and_wait/main.go
@@ -54,7 +54,10 @@ func main() {
 	// For debugging.
 	go http.ListenAndServe(fmt.Sprintf(":%d", httpPortTCP), nil)
 
-	go d.Run()
+	if err = d.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "DHT start error: %v", err)
+		os.Exit(1)
+	}
 	go drainresults(d)
 
 	for {

--- a/examples/find_infohash_and_wait/main6.go
+++ b/examples/find_infohash_and_wait/main6.go
@@ -69,7 +69,10 @@ func main() {
 			fmt.Fprintf(os.Stderr, "New DHT error: %v", err)
 			os.Exit(1)
 		}
-		go d6.Run()
+		if err = d6.Start(); err != nil {
+			fmt.Fprintf(os.Stderr, "DHT start error: %v", err)
+			os.Exit(1)
+		}
 		go drainresults(d6)
 	} else {
 		fmt.Fprintf(os.Stderr, "Not binding to IPv6 interface.  If desired pass -v6=[address] for the\n")
@@ -80,7 +83,10 @@ func main() {
 	// For debugging.
 	go http.ListenAndServe(fmt.Sprintf(":%d", httpPortTCP), nil)
 
-	go d4.Run()
+	if err = d4.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "DHT start error: %v", err)
+		os.Exit(1)
+	}
 	go drainresults(d4)
 	for {
 		d4.PeersRequest(string(ih), true)


### PR DESCRIPTION
following #44 and #45, squashed some commits and dicarded 35a06d1 which was misplaced and only applies to Run anyway, the deprecation warning should be enough hinting.  