### PR TITLE
Peerstore node maintenance implementation

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -504,9 +504,9 @@ func (d *DHT) getMorePeers(r *remoteNode) {
 	for ih := range d.peerStore.localActiveDownloads {
 		if d.needMorePeers(ih) {
 			if r == nil {
-				go d.getPeers(ih)
+				d.getPeers(ih)
 			} else {
-				go d.getPeersFrom(r, ih)
+				d.getPeersFrom(r, ih)
 			}
 		}
 	}

--- a/dht_test.go
+++ b/dht_test.go
@@ -13,12 +13,6 @@ import (
 	"github.com/nictuku/nettools"
 )
 
-func init() {
-	// TestDHTLocal requires contacting the same nodes multiple times, so
-	// shorten the retry period to make tests run faster.
-	searchRetryPeriod = time.Second
-}
-
 // ExampleDHT is a simple example that searches for a particular infohash and
 // exits when it finds any peers. A stand-alone version can be found in the
 // examples/ directory.
@@ -46,6 +40,8 @@ func ExampleDHT() {
 	tick := time.Tick(time.Second)
 
 	var infoHashPeers map[InfoHash][]string
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
 M:
 	for {
 		select {
@@ -55,7 +51,7 @@ M:
 			d.PeersRequest(string(infoHash), false)
 		case infoHashPeers = <-d.PeersRequestResults:
 			break M
-		case <-time.After(30 * time.Second):
+		case <-timer.C:
 			fmt.Printf("Could not find new peers: timed out")
 			return
 		}
@@ -125,6 +121,7 @@ func TestDHTLocal(t *testing.T) {
 		fmt.Println("Skipping TestDHTLocal")
 		return
 	}
+	searchRetryPeriod = time.Second
 	infoHash, err := DecodeInfoHash("d1c5676ae7ac98e8b19f63565905105e3c4c37a2")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -165,6 +162,7 @@ func TestDHTLocal(t *testing.T) {
 	n1.Stop()
 	n2.Stop()
 	n3.Stop()
+	searchRetryPeriod = time.Second * 15
 }
 
 // Requires Internet access and can be flaky if the server or the internet is

--- a/krpc.go
+++ b/krpc.go
@@ -123,6 +123,9 @@ func (r *remoteNode) wasContactedRecently(ih InfoHash) bool {
 			return true
 		}
 	}
+	if !r.lastSearchTime.IsZero() && time.Since(r.lastSearchTime) > searchRetryPeriod {
+		return false
+	}
 	for _, q := range r.pastQueries {
 		if q.ih == ih {
 			return true

--- a/neighborhood_test.go
+++ b/neighborhood_test.go
@@ -51,7 +51,7 @@ func TestUpkeep(t *testing.T) {
 		// there should be no sign of them later on.
 		n := randNodeId()
 		n[0] = byte(0x3d) // Ensure long distance.
-		r.neighborhoodUpkeep(genremoteNode(string(n)), "udp")
+		r.neighborhoodUpkeep(genremoteNode(string(n)), "udp", newPeerStore(0, 0))
 	}
 
 	// Current state: 8 neighbors with low proximity.
@@ -59,7 +59,7 @@ func TestUpkeep(t *testing.T) {
 	// Adds 7 neighbors from the static table. They should replace the
 	// random ones, except for one.
 	for _, v := range table[1:8] {
-		r.neighborhoodUpkeep(genremoteNode(v.rid), "udp")
+		r.neighborhoodUpkeep(genremoteNode(v.rid), "udp", newPeerStore(0, 0))
 	}
 
 	// Current state: 7 close neighbors, one distant dude.
@@ -80,7 +80,7 @@ func TestUpkeep(t *testing.T) {
 	if r.boundaryNode == nil {
 		t.Fatalf("tried to kill nil boundary node")
 	}
-	r.kill(r.boundaryNode)
+	r.kill(r.boundaryNode, newPeerStore(0, 0))
 
 	// The resulting boundary neighbor should now be one from the static
 	// table, with high proximity.

--- a/peer_store.go
+++ b/peer_store.go
@@ -22,28 +22,31 @@ func (p *peerContactsSet) next() []string {
 		count = len(p.set)
 	}
 	x := make([]string, 0, count)
+	xx := make(map[string]bool) //maps are easier to dedupe
 	for range p.set {
 		nid := p.ring.Move(1).Value.(string)
-		if p.set[nid] {
-			x = append(x, nid)
+		if _, ok := xx[nid]; p.set[nid] && !ok {
+			xx[nid] = true
 		}
-		if len(x) >= count {
+		if len(xx) >= count {
 			break
 		}
 	}
-	if len(x) < count {
+
+	if len(xx) < count {
 		for range p.set {
 			nid := p.ring.Move(1).Value.(string)
-			for j := range x {
-				if nid == x[j] {
-					continue
-				}
+			if _, ok := xx[nid]; ok {
+				continue
 			}
-			x = append(x, p.ring.Move(1).Value.(string))
-			if len(x) >= count {
+			xx[nid] = true
+			if len(xx) >= count {
 				break
 			}
 		}
+	}
+	for id := range xx {
+		x = append(x, id)
 	}
 	return x
 }


### PR DESCRIPTION
This adds the ability to maintain a fresh list of nodes in the peerstore, other additions include:
 - if we don't have enough nodes, try to bootstrap from the router
 - respect maxnodependingqueries
 - if a routingtable.lookupfiltered fails to return nodes, try routingtable.lookup
 - don't try to be smarter than the bittorrent client: if it asks for more nodes, forward the request to the dht (this helps if all the nodes we know are stuck)