### PR TITLE
improvements for crawling dht peers

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -96,7 +96,7 @@ type Config struct {
 	//Protocol for UDP connections, udp4= IPv4, udp6 = IPv6
 	UDPProto string
 	// Maximum get_peer requests per infoHash to prevent infinity loop in case NumTargetPeers is set 
-	// real high. This is only usefull in crawler mode, since hashes will expire via MaxInfoHashes
+	// real high. Counter will expire/reset after 10 Minutes
 	MaxSearchQueries int
 }
 
@@ -704,6 +704,7 @@ func (d *DHT) getPeersFrom(r *remoteNode, ih InfoHash) {
 		return
 	}
 	totalSentGetPeers.Add(1)
+	// if MaxSearchQueries is set and reached, don't send new get_peers
 	cnt := d.peerStore.addSearchCount(ih)
 	if d.config.MaxSearchQueries > 0 && cnt > d.config.MaxSearchQueries {
 		return

--- a/dht.go
+++ b/dht.go
@@ -96,8 +96,10 @@ type Config struct {
 	//Protocol for UDP connections, udp4= IPv4, udp6 = IPv6
 	UDPProto string
 	// Maximum get_peer requests per infoHash to prevent infinity loop in case NumTargetPeers is set 
-	// real high. Counter will expire/reset after 10 Minutes
+	// real high. 
 	MaxSearchQueries int
+	// MaxSearchQueries counter will be reset after that time
+	SearchCntExpire time.Duration
 }
 
 // Creates a *Config populated with default values.
@@ -119,6 +121,7 @@ func NewConfig() *Config {
 		ThrottlerTrackedClients: 1000,
 		UDPProto:                "udp4",
 		MaxSearchQueries:        -1,
+		SearchCntExpire:         10 * time.Minute,
 	}
 }
 
@@ -187,7 +190,7 @@ func New(config *Config) (node *DHT, err error) {
 	node = &DHT{
 		config:               cfg,
 		routingTable:         newRoutingTable(),
-		peerStore:            newPeerStore(cfg.MaxInfoHashes, cfg.MaxInfoHashPeers, cfg.MaxNodes),
+		peerStore:            newPeerStore(cfg.MaxInfoHashes, cfg.MaxInfoHashPeers, cfg.MaxNodes, cfg.SearchCntExpire),
 		PeersRequestResults:  make(chan map[InfoHash][]string, 1),
 		stop:                 make(chan bool),
 		exploredNeighborhood: false,

--- a/dht_test.go
+++ b/dht_test.go
@@ -31,7 +31,7 @@ func ExampleDHT() {
 		return
 	}
 
-	infoHash, err := DecodeInfoHash("d1c5676ae7ac98e8b19f63565905105e3c4c37a2")
+	infoHash, err := DecodeInfoHash("c3c5fe05c329ae51c6eca464f6b30ba0a457b2ca")
 	if err != nil {
 		fmt.Printf("DecodeInfoHash faiure: %v", err)
 		return
@@ -63,7 +63,7 @@ M:
 			//	fmt.Println(DecodePeerAddress(peer))
 			//}
 
-			if fmt.Sprintf("%x", ih) == "d1c5676ae7ac98e8b19f63565905105e3c4c37a2" {
+			if fmt.Sprintf("%x", ih) == "c3c5fe05c329ae51c6eca464f6b30ba0a457b2ca" {
 				fmt.Println("Peer found for the requested infohash or the test was skipped")
 				return
 			}
@@ -122,7 +122,7 @@ func TestDHTLocal(t *testing.T) {
 		return
 	}
 	searchRetryPeriod = time.Second
-	infoHash, err := DecodeInfoHash("d1c5676ae7ac98e8b19f63565905105e3c4c37a2")
+	infoHash, err := DecodeInfoHash("c3c5fe05c329ae51c6eca464f6b30ba0a457b2ca")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/examples/find_infohash_and_wait/btkador.go
+++ b/examples/find_infohash_and_wait/btkador.go
@@ -1,0 +1,102 @@
+// Runs a node on a random UDP port that attempts to collect 10 peers for an
+// infohash, then keeps running as a passive DHT node.
+//
+// IMPORTANT: if the UDP port is not reachable from the public internet, you
+// may see very few results.
+//
+// To collect 10 peers, it usually has to contact some 1k nodes. It's much easier
+// to find peers for popular infohashes. This process is not instant and should
+// take a minute or two, depending on your network connection.
+//
+//
+// There is a builtin web server that can be used to collect debugging stats
+// from http://localhost:8711/debug/vars.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/btkador/dht"
+)
+
+const (
+	httpPortTCP = 8711
+	numTarget   = 5000
+	exampleIH   = "C3C5FE05C329AE51C6ECA464F6B30BA0A457B2CA" // ubuntu-16.04.5-desktop-amd64.iso
+)
+
+func main() {
+	flag.Parse()
+	// To see logs, use the -logtostderr flag and change the verbosity with
+	// -v 0 (less verbose) up to -v 5 (more verbose).
+	if len(flag.Args()) != 1 {
+		fmt.Fprintf(os.Stderr, "Usage: %v <infohash>\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Example infohash: %v\n", exampleIH)
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+	ih, err := dht.DecodeInfoHash(flag.Args()[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "DecodeInfoHash error: %v\n", err)
+		os.Exit(1)
+	}
+	// Starts a DHT node with the default options. It picks a random UDP port. To change this, see dht.NewConfig.
+	d, err := dht.New(&dht.Config{
+                Address:                 "",
+                Port:                    0, // Picks a random port.
+                NumTargetPeers:          5000,
+                DHTRouters:              "router.magnets.im:6881,router.bittorrent.com:6881,dht.transmissionbt.com:6881",
+                MaxNodes:                500,
+                CleanupPeriod:           15 * time.Minute,
+                SaveRoutingTable:        true,
+                SavePeriod:              5 * time.Minute,
+                RateLimit:               -1,
+                MaxInfoHashes:           2048,
+                MaxInfoHashPeers:        256,
+                ClientPerMinuteLimit:    50,
+                ThrottlerTrackedClients: 1000,
+                UDPProto:                "udp4",
+                MaxSearchQueries:        1000,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "New DHT error: %v", err)
+		os.Exit(1)
+
+	}
+	// For debugging.
+	go http.ListenAndServe(fmt.Sprintf(":%d", httpPortTCP), nil)
+
+	if err = d.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "DHT start error: %v", err)
+		os.Exit(1)
+	}
+	go drainresults(d)
+
+	for {
+		d.PeersRequest(string(ih), false)
+		time.Sleep(5 * time.Minute)
+	}
+}
+
+// drainresults loops, printing the address of nodes it has found.
+func drainresults(n *dht.DHT) {
+	count := 0
+	fmt.Println("=========================== DHT")
+	fmt.Println("Note that there are many bad nodes that reply to anything you ask.")
+	fmt.Println("Peers found:")
+	for r := range n.PeersRequestResults {
+		for _, peers := range r {
+			for _, x := range peers {
+				fmt.Printf("%d: %v\n", count, dht.DecodePeerAddress(x))
+				count++
+				//if count >= numTarget {
+				//	os.Exit(0)
+				//}
+			}
+		}
+	}
+}

--- a/krpc.go
+++ b/krpc.go
@@ -32,6 +32,7 @@ type remoteNode struct {
 	pendingQueries   map[string]*queryType // key: transaction ID
 	pastQueries      map[string]*queryType // key: transaction ID
 	reachable        bool
+	createTime       time.Time
 	lastResponseTime time.Time
 	lastSearchTime   time.Time
 	ActiveDownloads  []string // List of infohashes we know this peer is downloading.
@@ -44,6 +45,7 @@ func newRemoteNode(addr net.UDPAddr, id string) *remoteNode {
 		lastQueryID:         newTransactionId(),
 		id:                  id,
 		reachable:           false,
+		createTime:          time.Now(),
 		pendingQueries:      map[string]*queryType{},
 		pastQueries:         map[string]*queryType{},
 	}

--- a/krpc_test.go
+++ b/krpc_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestDecodeInfoHash(t *testing.T) {
-	infoHash, err := DecodeInfoHash("d1c5676ae7ac98e8b19f63565905105e3c4c37a2")
+	infoHash, err := DecodeInfoHash("c3c5fe05c329ae51c6eca464f6b30ba0a457b2ca")
 	if err != nil {
 		t.Fatalf("DecodeInfoHash faiure: %v", err)
 	}

--- a/neighborhood_test.go
+++ b/neighborhood_test.go
@@ -51,7 +51,7 @@ func TestUpkeep(t *testing.T) {
 		// there should be no sign of them later on.
 		n := randNodeId()
 		n[0] = byte(0x3d) // Ensure long distance.
-		r.neighborhoodUpkeep(genremoteNode(string(n)), "udp", newPeerStore(0, 0))
+		r.neighborhoodUpkeep(genremoteNode(string(n)), "udp", newPeerStore(0, 0, 0))
 	}
 
 	// Current state: 8 neighbors with low proximity.
@@ -59,7 +59,7 @@ func TestUpkeep(t *testing.T) {
 	// Adds 7 neighbors from the static table. They should replace the
 	// random ones, except for one.
 	for _, v := range table[1:8] {
-		r.neighborhoodUpkeep(genremoteNode(v.rid), "udp", newPeerStore(0, 0))
+		r.neighborhoodUpkeep(genremoteNode(v.rid), "udp", newPeerStore(0, 0, 0))
 	}
 
 	// Current state: 7 close neighbors, one distant dude.
@@ -80,7 +80,7 @@ func TestUpkeep(t *testing.T) {
 	if r.boundaryNode == nil {
 		t.Fatalf("tried to kill nil boundary node")
 	}
-	r.kill(r.boundaryNode, newPeerStore(0, 0))
+	r.kill(r.boundaryNode, newPeerStore(0, 0, 0))
 
 	// The resulting boundary neighbor should now be one from the static
 	// table, with high proximity.

--- a/neighborhood_test.go
+++ b/neighborhood_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"net"
 	"testing"
+	"time"
 )
 
 const (
@@ -51,7 +52,7 @@ func TestUpkeep(t *testing.T) {
 		// there should be no sign of them later on.
 		n := randNodeId()
 		n[0] = byte(0x3d) // Ensure long distance.
-		r.neighborhoodUpkeep(genremoteNode(string(n)), "udp", newPeerStore(0, 0, 0))
+		r.neighborhoodUpkeep(genremoteNode(string(n)), "udp", newPeerStore(0, 0, 0, 10 * time.Minute))
 	}
 
 	// Current state: 8 neighbors with low proximity.
@@ -59,7 +60,7 @@ func TestUpkeep(t *testing.T) {
 	// Adds 7 neighbors from the static table. They should replace the
 	// random ones, except for one.
 	for _, v := range table[1:8] {
-		r.neighborhoodUpkeep(genremoteNode(v.rid), "udp", newPeerStore(0, 0, 0))
+		r.neighborhoodUpkeep(genremoteNode(v.rid), "udp", newPeerStore(0, 0, 0, 10 * time.Minute))
 	}
 
 	// Current state: 7 close neighbors, one distant dude.
@@ -80,7 +81,7 @@ func TestUpkeep(t *testing.T) {
 	if r.boundaryNode == nil {
 		t.Fatalf("tried to kill nil boundary node")
 	}
-	r.kill(r.boundaryNode, newPeerStore(0, 0, 0))
+	r.kill(r.boundaryNode, newPeerStore(0, 0, 0, 10 * time.Minute))
 
 	// The resulting boundary neighbor should now be one from the static
 	// table, with high proximity.

--- a/peer_store.go
+++ b/peer_store.go
@@ -127,11 +127,11 @@ func (p *peerContactsSet) Alive() int {
 	return ret
 }
 
-func newPeerStore(maxInfoHashes, maxInfoHashPeers, maxNodes int) *peerStore {
+func newPeerStore(maxInfoHashes, maxInfoHashPeers, maxNodes int, SearchCntExpire time.Duration) *peerStore {
 	return &peerStore{
 		infoHashPeers:        lru.New(maxInfoHashes),
 		localActiveDownloads: make(map[InfoHash]bool),
-		searchCount:          cache.New(10*time.Minute, 5*time.Minute),
+		searchCount:          cache.New(SearchCntExpire, time.Duration(SearchCntExpire/2)),
 		maxInfoHashes:        maxInfoHashes,
 		maxInfoHashPeers:     maxInfoHashPeers,
 		maxNodes:             maxNodes,

--- a/peer_store_test.go
+++ b/peer_store_test.go
@@ -2,6 +2,7 @@ package dht
 
 import (
 	"testing"
+	"time"
 )
 
 func TestPeerStorage(t *testing.T) {
@@ -10,7 +11,7 @@ func TestPeerStorage(t *testing.T) {
 		t.Fatalf("DecodeInfoHash: %v", err)
 	}
 	// Allow 1 IH and 2 peers.
-	p := newPeerStore(1, 2, 0)
+	p := newPeerStore(1, 2, 0, 10 * time.Minute)
 
 	if ok := p.addContact(ih, "abcedf"); !ok {
 		t.Fatalf("addContact(1/2) expected true, got false")

--- a/peer_store_test.go
+++ b/peer_store_test.go
@@ -5,12 +5,12 @@ import (
 )
 
 func TestPeerStorage(t *testing.T) {
-	ih, err := DecodeInfoHash("d1c5676ae7ac98e8b19f63565905105e3c4c37a2")
+	ih, err := DecodeInfoHash("c3c5fe05c329ae51c6eca464f6b30ba0a457b2ca")
 	if err != nil {
 		t.Fatalf("DecodeInfoHash: %v", err)
 	}
 	// Allow 1 IH and 2 peers.
-	p := newPeerStore(1, 2)
+	p := newPeerStore(1, 2, 0)
 
 	if ok := p.addContact(ih, "abcedf"); !ok {
 		t.Fatalf("addContact(1/2) expected true, got false")
@@ -31,7 +31,7 @@ func TestPeerStorage(t *testing.T) {
 		t.Fatalf("Added 3rd contact, got count %v, wanted 2", p.count(ih))
 	}
 
-	ih2, err := DecodeInfoHash("deca7a89a1dbdc4b213de1c0d5351e92582f31fb")
+	ih2, err := DecodeInfoHash("e84213a794f3ccd890382a54a64ca68b7e925433")
 	if err != nil {
 		t.Fatalf("DecodeInfoHash: %v", err)
 	}

--- a/routing_table.go
+++ b/routing_table.go
@@ -206,6 +206,12 @@ func (r *routingTable) cleanup(cleanupPeriod time.Duration, p *peerStore) (needP
 			r.kill(n, p)
 			continue
 		}
+                // kill old and currently unused nodes if nodeCount is > maxNodes
+                if len(r.addresses) > p.maxNodes && time.Since(n.createTime) > cleanupPeriod && len(n.pendingQueries) == 0 {
+                        log.V(4).Infof("DHT: Old node with 0 pendingQueries. Deleting")
+                        r.kill(n, p)
+                        continue
+                }
 		if n.reachable {
 			if len(n.pendingQueries) == 0 {
 				goto PING


### PR DESCRIPTION
* added few more well known `DHTRouters`

* added optional `PassiveMode` parameter, so the server doesn't responde to any incoming queries (get_peers, ping, etc)

* added optional `MaxSearchQueries` parameter to limit the number of generated get_peers queries per hash. If NumTargetPeers is set to ie 5000 the server will infinityfly create new get_peers requests, till NumTargetPeers is reached - which may create a lot of packets and traffic that can't be handled any more. Especial if the hash has only 5 peers out there, the server will keep sending new requests. With `MaxSearchQueries` set, this will hard limit the number of new get_peers queries per hash. The counter will reset (per hash) after `SearchCntExpire` (default 10 minutes).

* added an expiration timer for nodes. This will only take effect if `MaxNodes` limit is reached, and purge old (> CleanupPeriod) nodes without pendingQueries, till MaxNodes is reached again.

* replaced the old Ubuntu Iso fileHash in `tests` with a current one