### PR TITLE
introduce DebugLogger interface

### DIFF
--- a/dht.go
+++ b/dht.go
@@ -137,7 +137,7 @@ type DHT struct {
 	peerStore              *peerStore
 	conn                   *net.UDPConn
 	Logger                 Logger
-	Logger2                Logger2
+	DebugLogger            DebugLogger
 	exploredNeighborhood   bool
 	remoteNodeAcquaintance chan string
 	peersRequest           chan ihReq
@@ -170,7 +170,7 @@ func New(config *Config) (node *DHT, err error) {
 		peerStore:            newPeerStore(cfg.MaxInfoHashes, cfg.MaxInfoHashPeers),
 		PeersRequestResults:  make(chan map[InfoHash][]string, 1),
 		stop:                 make(chan bool),
-		Logger2:              &nullLogger{},
+		DebugLogger:          &nullLogger{},
 		exploredNeighborhood: false,
 		// Buffer to avoid blocking on sends.
 		remoteNodeAcquaintance: make(chan string, 100),
@@ -190,7 +190,7 @@ func New(config *Config) (node *DHT, err error) {
 		if err != nil {
 			return nil, err
 		}
-		node.Logger2.Debugf("Using a new random node ID: %x %d", c.Id, len(c.Id))
+		node.DebugLogger.Debugf("Using a new random node ID: %x %d", c.Id, len(c.Id))
 		saveStore(*c)
 	}
 	// The types don't match because JSON marshalling needs []byte.
@@ -215,7 +215,7 @@ func (d *DHT) newTokenSecret() string {
 	b := make([]byte, 5)
 	if _, err := rand.Read(b); err != nil {
 		// This would return a string with up to 5 null chars.
-		d.Logger2.Errorf("DHT: failed to generate random newTokenSecret: %v", err)
+		d.DebugLogger.Errorf("DHT: failed to generate random newTokenSecret: %v", err)
 	}
 	return string(b)
 }
@@ -237,7 +237,7 @@ type ihReq struct {
 // is just a router that doesn't downloads torrents.
 func (d *DHT) PeersRequest(ih string, announce bool) {
 	d.peersRequest <- ihReq{InfoHash(ih), announce}
-	d.Logger2.Infof("DHT: torrent client asking more peers for %x.", ih)
+	d.DebugLogger.Infof("DHT: torrent client asking more peers for %x.", ih)
 }
 
 // Stop the DHT node.
@@ -320,7 +320,7 @@ func (d *DHT) Start() (err error) {
 // If initSocket succeeds, Run blocks until d.Stop() is called.
 // DEPRECATED - Start should be used instead of Run
 func (d *DHT) Run() error {
-	d.Logger2.Infof("dht.Run() is deprecated, use dht.Start() instead")
+	d.DebugLogger.Infof("dht.Run() is deprecated, use dht.Start() instead")
 	if err := d.initSocket(); err != nil {
 		return err
 	}
@@ -392,7 +392,7 @@ func (d *DHT) loop() {
 	tokenBucket := d.config.RateLimit
 
 	if d.config.RateLimit < 0 {
-		d.Logger2.Infof("rate limiting disabled")
+		d.DebugLogger.Infof("rate limiting disabled")
 	} else {
 		// Token bucket for limiting the number of packets per second.
 		fillTokenBucket = time.Tick(time.Second / 10)
@@ -401,12 +401,12 @@ func (d *DHT) loop() {
 			d.config.RateLimit = 10
 		}
 	}
-	d.Logger2.Infof("DHT: Starting DHT node %x on port %d.", d.nodeId, d.config.Port)
+	d.DebugLogger.Infof("DHT: Starting DHT node %x on port %d.", d.nodeId, d.config.Port)
 
 	for {
 		select {
 		case <-d.stop:
-			d.Logger2.Infof("DHT exiting.")
+			d.DebugLogger.Infof("DHT exiting.")
 			d.clientThrottle.Stop()
 			return
 		case addr := <-d.remoteNodeAcquaintance:
@@ -526,7 +526,7 @@ func (d *DHT) helloFromPeer(addr string) {
 	// - if it responds, save it in the routing table.
 	_, addrResolved, existed, err := d.routingTable.hostPortToNode(addr, d.config.UDPProto)
 	if err != nil {
-		d.Logger2.Debugf("helloFromPeer error: %v", err)
+		d.DebugLogger.Debugf("helloFromPeer error: %v", err)
 		return
 	}
 	if existed {
@@ -540,42 +540,42 @@ func (d *DHT) helloFromPeer(addr string) {
 }
 
 func (d *DHT) processPacket(p packetType) {
-	d.Logger2.Debugf("DHT processing packet from %v", p.raddr.String())
+	d.DebugLogger.Debugf("DHT processing packet from %v", p.raddr.String())
 	if !d.clientThrottle.CheckBlock(p.raddr.IP.String()) {
 		totalPacketsFromBlockedHosts.Add(1)
-		d.Logger2.Debugf("Node exceeded rate limiter. Dropping packet.")
+		d.DebugLogger.Debugf("Node exceeded rate limiter. Dropping packet.")
 		return
 	}
 	if p.b[0] != 'd' {
 		// Malformed DHT packet. There are protocol extensions out
 		// there that we don't support or understand.
-		d.Logger2.Debugf("Malformed DHT packet.")
+		d.DebugLogger.Debugf("Malformed DHT packet.")
 		return
 	}
 	r, err := readResponse(p)
 	if err != nil {
-		d.Logger2.Debugf("DHT: readResponse Error: %v, %q", err, string(p.b))
+		d.DebugLogger.Debugf("DHT: readResponse Error: %v, %q", err, string(p.b))
 		return
 	}
 	switch {
 	// Response.
 	case r.Y == "r":
-		d.Logger2.Debugf("DHT processing response from %x", r.R.Id)
+		d.DebugLogger.Debugf("DHT processing response from %x", r.R.Id)
 		if bogusId(r.R.Id) {
-			d.Logger2.Debugf("DHT received packet with bogus node id %x", r.R.Id)
+			d.DebugLogger.Debugf("DHT received packet with bogus node id %x", r.R.Id)
 			return
 		}
 		if r.R.Id == d.nodeId {
-			d.Logger2.Debugf("DHT received reply from self, id %x", r.A.Id)
+			d.DebugLogger.Debugf("DHT received reply from self, id %x", r.A.Id)
 			return
 		}
 		node, addr, existed, err := d.routingTable.hostPortToNode(p.raddr.String(), d.config.UDPProto)
 		if err != nil {
-			d.Logger2.Debugf("DHT readResponse error processing response: %v", err)
+			d.DebugLogger.Debugf("DHT readResponse error processing response: %v", err)
 			return
 		}
 		if !existed {
-			d.Logger2.Debugf("DHT: Received reply from a host we don't know: %v", p.raddr)
+			d.DebugLogger.Debugf("DHT: Received reply from a host we don't know: %v", p.raddr)
 			if d.routingTable.length() < d.config.MaxNodes {
 				d.ping(addr)
 			}
@@ -587,10 +587,10 @@ func (d *DHT) processPacket(p packetType) {
 			d.routingTable.update(node, d.config.UDPProto)
 		}
 		if node.id != r.R.Id {
-			d.Logger2.Debugf("DHT: Node changed IDs %x => %x", node.id, r.R.Id)
+			d.DebugLogger.Debugf("DHT: Node changed IDs %x => %x", node.id, r.R.Id)
 		}
 		if query, ok := node.pendingQueries[r.T]; ok {
-			d.Logger2.Debugf("DHT: Received reply to %v", query.Type)
+			d.DebugLogger.Debugf("DHT: Received reply to %v", query.Type)
 			if !node.reachable {
 				node.reachable = true
 				totalNodesReached.Add(1)
@@ -602,7 +602,7 @@ func (d *DHT) processPacket(p packetType) {
 			// If this is the first host added to the routing table, attempt a
 			// recursive lookup of our own address, to build our neighborhood ASAP.
 			if d.needMoreNodes() {
-				d.Logger2.Debugf("DHT: need more nodes")
+				d.DebugLogger.Debugf("DHT: need more nodes")
 				d.findNode(d.nodeId)
 			}
 			d.exploredNeighborhood = true
@@ -612,28 +612,28 @@ func (d *DHT) processPacket(p packetType) {
 				// Served its purpose, nothing else to be done.
 				totalRecvPingReply.Add(1)
 			case "get_peers":
-				d.Logger2.Debugf("DHT: got get_peers response")
+				d.DebugLogger.Debugf("DHT: got get_peers response")
 				d.processGetPeerResults(node, r)
 			case "find_node":
-				d.Logger2.Debugf("DHT: got find_node response")
+				d.DebugLogger.Debugf("DHT: got find_node response")
 				d.processFindNodeResults(node, r)
 			case "announce_peer":
 				// Nothing to do. In the future, update counters.
 			default:
-				d.Logger2.Debugf("DHT: Unknown query type: %v from %v", query.Type, addr)
+				d.DebugLogger.Debugf("DHT: Unknown query type: %v from %v", query.Type, addr)
 			}
 			delete(node.pendingQueries, r.T)
 		} else {
-			d.Logger2.Debugf("DHT: Unknown query id: %v", r.T)
+			d.DebugLogger.Debugf("DHT: Unknown query id: %v", r.T)
 		}
 	case r.Y == "q":
 		if r.A.Id == d.nodeId {
-			d.Logger2.Debugf("DHT received packet from self, id %x", r.A.Id)
+			d.DebugLogger.Debugf("DHT received packet from self, id %x", r.A.Id)
 			return
 		}
 		node, addr, existed, err := d.routingTable.hostPortToNode(p.raddr.String(), d.config.UDPProto)
 		if err != nil {
-			d.Logger2.Debugf("Error readResponse error processing query: %v", err)
+			d.DebugLogger.Debugf("Error readResponse error processing query: %v", err)
 			return
 		}
 		if !existed {
@@ -642,7 +642,7 @@ func (d *DHT) processPacket(p packetType) {
 				d.ping(addr)
 			}
 		}
-		d.Logger2.Debugf("DHT processing %v request", r.Q)
+		d.DebugLogger.Debugf("DHT processing %v request", r.Q)
 		switch r.Q {
 		case "ping":
 			d.replyPing(p.raddr, r)
@@ -653,24 +653,24 @@ func (d *DHT) processPacket(p packetType) {
 		case "announce_peer":
 			d.replyAnnouncePeer(p.raddr, node, r)
 		default:
-			d.Logger2.Debugf("DHT: non-implemented handler for type %v", r.Q)
+			d.DebugLogger.Debugf("DHT: non-implemented handler for type %v", r.Q)
 		}
 	default:
-		d.Logger2.Debugf("DHT: Bogus DHT query from %v.", p.raddr)
+		d.DebugLogger.Debugf("DHT: Bogus DHT query from %v.", p.raddr)
 	}
 }
 
 func (d *DHT) ping(address string) {
 	r, err := d.routingTable.getOrCreateNode("", address, d.config.UDPProto)
 	if err != nil {
-		d.Logger2.Debugf("ping error for address %v: %v", address, err)
+		d.DebugLogger.Debugf("ping error for address %v: %v", address, err)
 		return
 	}
 	d.pingNode(r)
 }
 
 func (d *DHT) pingNode(r *remoteNode) {
-	d.Logger2.Debugf("DHT: ping => %+v", r.address)
+	d.DebugLogger.Debugf("DHT: ping => %+v", r.address)
 	t := r.newQuery("ping")
 
 	queryArguments := map[string]interface{}{"id": d.nodeId}
@@ -696,7 +696,7 @@ func (d *DHT) getPeersFrom(r *remoteNode, ih InfoHash) {
 		"info_hash": ih,
 	}
 	query := queryMessage{transId, "q", ty, queryArguments}
-	d.Logger2.Debugf("DHT sending get_peers. nodeID: %x@%v, InfoHash: %x , distance: %x", r.id, r.address, ih, hashDistance(InfoHash(r.id), ih))
+	d.DebugLogger.Debugf("DHT sending get_peers. nodeID: %x@%v, InfoHash: %x , distance: %x", r.id, r.address, ih, hashDistance(InfoHash(r.id), ih))
 	r.lastSearchTime = time.Now()
 	sendMsg(d.conn, r.address, query)
 }
@@ -709,7 +709,7 @@ func (d *DHT) findNodeFrom(r *remoteNode, id string) {
 	ty := "find_node"
 	transId := r.newQuery(ty)
 	ih := InfoHash(id)
-	d.Logger2.Debugf("findNodeFrom adding pendingQueries transId=%v ih=%x", transId, ih)
+	d.DebugLogger.Debugf("findNodeFrom adding pendingQueries transId=%v ih=%x", transId, ih)
 	if _, ok := r.pendingQueries[transId]; ok {
 		r.pendingQueries[transId].ih = ih
 	} else {
@@ -720,7 +720,7 @@ func (d *DHT) findNodeFrom(r *remoteNode, id string) {
 		"target": id,
 	}
 	query := queryMessage{transId, "q", ty, queryArguments}
-	d.Logger2.Debugf("DHT sending find_node. nodeID: %x@%v, target ID: %x , distance: %x", r.id, r.address, id, hashDistance(InfoHash(r.id), ih))
+	d.DebugLogger.Debugf("DHT sending find_node. nodeID: %x@%v, target ID: %x , distance: %x", r.id, r.address, id, hashDistance(InfoHash(r.id), ih))
 	r.lastSearchTime = time.Now()
 	sendMsg(d.conn, r.address, query)
 }
@@ -731,11 +731,11 @@ func (d *DHT) findNodeFrom(r *remoteNode, id string) {
 func (d *DHT) announcePeer(address net.UDPAddr, ih InfoHash, token string) {
 	r, err := d.routingTable.getOrCreateNode("", address.String(), d.config.UDPProto)
 	if err != nil {
-		d.Logger2.Debugf("announcePeer error: %v", err)
+		d.DebugLogger.Debugf("announcePeer error: %v", err)
 		return
 	}
 	ty := "announce_peer"
-	d.Logger2.Debugf("DHT: announce_peer => address: %v, ih: %x, token: %x", address, ih, token)
+	d.DebugLogger.Debugf("DHT: announce_peer => address: %v, ih: %x, token: %x", address, ih, token)
 	transId := r.newQuery(ty)
 	queryArguments := map[string]interface{}{
 		"id":        d.nodeId,
@@ -762,13 +762,13 @@ func (d *DHT) checkToken(addr net.UDPAddr, token string) bool {
 			break
 		}
 	}
-	d.Logger2.Debugf("checkToken for %v, %q matches? %v", addr, token, match)
+	d.DebugLogger.Debugf("checkToken for %v, %q matches? %v", addr, token, match)
 	return match
 }
 
 func (d *DHT) replyAnnouncePeer(addr net.UDPAddr, node *remoteNode, r responseType) {
 	ih := InfoHash(r.A.InfoHash)
-	d.Logger2.Debugf("DHT: announce_peer. Host %v, nodeID: %x, infoHash: %x, peerPort %d, distance to me %x",
+	d.DebugLogger.Debugf("DHT: announce_peer. Host %v, nodeID: %x, infoHash: %x, peerPort %d, distance to me %x",
 		addr, r.A.Id, ih, r.A.Port, hashDistance(ih, InfoHash(d.nodeId)),
 	)
 	// node can be nil if, for example, the server just restarted and received an announce_peer
@@ -795,7 +795,7 @@ func (d *DHT) replyAnnouncePeer(addr net.UDPAddr, node *remoteNode, r responseTy
 
 func (d *DHT) replyGetPeers(addr net.UDPAddr, r responseType) {
 	totalRecvGetPeers.Add(1)
-	d.Logger2.Debugf("DHT get_peers. Host: %v , nodeID: %x , InfoHash: %x , distance to me: %x",
+	d.DebugLogger.Debugf("DHT get_peers. Host: %v , nodeID: %x , InfoHash: %x , distance to me: %x",
 		addr, r.A.Id, InfoHash(r.A.InfoHash), hashDistance(r.A.InfoHash, InfoHash(d.nodeId)))
 
 	if d.Logger != nil {
@@ -825,28 +825,28 @@ func (d *DHT) nodesForInfoHash(ih InfoHash) string {
 		if r != nil {
 			binaryHost := r.id + nettools.DottedPortToBinary(r.address.String())
 			if binaryHost == "" {
-				d.Logger2.Debugf("killing node with bogus address %v", r.address.String())
+				d.DebugLogger.Debugf("killing node with bogus address %v", r.address.String())
 				d.routingTable.kill(r, d.peerStore)
 			} else {
 				n = append(n, binaryHost)
 			}
 		}
 	}
-	d.Logger2.Debugf("replyGetPeers: Nodes only. Giving %d", len(n))
+	d.DebugLogger.Debugf("replyGetPeers: Nodes only. Giving %d", len(n))
 	return strings.Join(n, "")
 }
 
 func (d *DHT) peersForInfoHash(ih InfoHash) []string {
 	peerContacts := d.peerStore.peerContacts(ih)
 	if len(peerContacts) > 0 {
-		d.Logger2.Debugf("replyGetPeers: Giving peers! %x was requested, and we knew %d peers!", ih, len(peerContacts))
+		d.DebugLogger.Debugf("replyGetPeers: Giving peers! %x was requested, and we knew %d peers!", ih, len(peerContacts))
 	}
 	return peerContacts
 }
 
 func (d *DHT) replyFindNode(addr net.UDPAddr, r responseType) {
 	totalRecvFindNode.Add(1)
-	d.Logger2.Debugf("DHT find_node. Host: %v , nodeId: %x , target ID: %x , distance to me: %x",
+	d.DebugLogger.Debugf("DHT find_node. Host: %v , nodeId: %x , target ID: %x , distance to me: %x",
 		addr, r.A.Id, r.A.Target, hashDistance(InfoHash(r.A.Target), InfoHash(d.nodeId)))
 
 	node := InfoHash(r.A.Target)
@@ -868,13 +868,13 @@ func (d *DHT) replyFindNode(addr net.UDPAddr, r responseType) {
 			break
 		}
 	}
-	d.Logger2.Debugf("replyFindNode: Nodes only. Giving %d", len(n))
+	d.DebugLogger.Debugf("replyFindNode: Nodes only. Giving %d", len(n))
 	reply.R["nodes"] = strings.Join(n, "")
 	sendMsg(d.conn, addr, reply)
 }
 
 func (d *DHT) replyPing(addr net.UDPAddr, response responseType) {
-	d.Logger2.Debugf("DHT: reply ping => %v", addr)
+	d.DebugLogger.Debugf("DHT: reply ping => %v", addr)
 	reply := replyMessage{
 		T: response.T,
 		Y: "r",
@@ -907,7 +907,7 @@ func (d *DHT) processGetPeerResults(node *remoteNode, resp responseType) {
 			// Finally, new peers.
 			result := map[InfoHash][]string{query.ih: peers}
 			totalPeers.Add(int64(len(peers)))
-			d.Logger2.Debugf("DHT: processGetPeerResults, totalPeers: %v", totalPeers.String())
+			d.DebugLogger.Debugf("DHT: processGetPeerResults, totalPeers: %v", totalPeers.String())
 			select {
 			case d.PeersRequestResults <- result:
 			case <-d.stop:
@@ -923,18 +923,18 @@ func (d *DHT) processGetPeerResults(node *remoteNode, resp responseType) {
 	} else if d.config.UDPProto == "udp6" {
 		nodelist = resp.R.Nodes6
 	}
-	d.Logger2.Debugf("DHT: handling get_peers results len(nodelist)=%d", len(nodelist))
+	d.DebugLogger.Debugf("DHT: handling get_peers results len(nodelist)=%d", len(nodelist))
 	if nodelist != "" {
 		for id, address := range parseNodesString(nodelist, d.config.UDPProto) {
 			if id == d.nodeId {
-				d.Logger2.Debugf("DHT got reference of self for get_peers, id %x", id)
+				d.DebugLogger.Debugf("DHT got reference of self for get_peers, id %x", id)
 				continue
 			}
 
 			// If it's in our routing table already, ignore it.
 			_, addr, existed, err := d.routingTable.hostPortToNode(address, d.config.UDPProto)
 			if err != nil {
-				d.Logger2.Debugf("DHT error parsing get peers node: %v", err)
+				d.DebugLogger.Debugf("DHT error parsing get peers node: %v", err)
 				continue
 			}
 			if addr == node.address.String() {
@@ -946,12 +946,12 @@ func (d *DHT) processGetPeerResults(node *remoteNode, resp responseType) {
 				continue
 			}
 			if existed {
-				d.Logger2.Debugf("DHT: processGetPeerResults DUPE node reference: %x@%v from %x@%v. Distance: %x.",
+				d.DebugLogger.Debugf("DHT: processGetPeerResults DUPE node reference: %x@%v from %x@%v. Distance: %x.",
 					id, address, node.id, node.address, hashDistance(query.ih, InfoHash(node.id)))
 				totalGetPeersDupes.Add(1)
 			} else {
 				// And it is actually new. Interesting.
-				d.Logger2.Debugf("DHT: Got new node reference: %x@%v from %x@%v. Distance: %x.",
+				d.DebugLogger.Debugf("DHT: Got new node reference: %x@%v from %x@%v. Distance: %x.",
 					id, address, node.id, node.address, hashDistance(query.ih, InfoHash(node.id)))
 				if _, err := d.routingTable.getOrCreateNode(id, addr, d.config.UDPProto); err == nil && d.needMorePeers(query.ih) {
 					// Re-add this request to the queue. This would in theory
@@ -993,17 +993,17 @@ func (d *DHT) processFindNodeResults(node *remoteNode, resp responseType) {
 	} else if d.config.UDPProto == "udp6" {
 		nodelist = resp.R.Nodes6
 	}
-	d.Logger2.Debugf("processFindNodeResults find_node = %s len(nodelist)=%d", nettools.BinaryToDottedPort(node.addressBinaryFormat), len(nodelist))
+	d.DebugLogger.Debugf("processFindNodeResults find_node = %s len(nodelist)=%d", nettools.BinaryToDottedPort(node.addressBinaryFormat), len(nodelist))
 
 	if nodelist != "" {
 		for id, address := range parseNodesString(nodelist, d.config.UDPProto) {
 			_, addr, existed, err := d.routingTable.hostPortToNode(address, d.config.UDPProto)
 			if err != nil {
-				d.Logger2.Debugf("DHT error parsing node from find_find response: %v", err)
+				d.DebugLogger.Debugf("DHT error parsing node from find_find response: %v", err)
 				continue
 			}
 			if id == d.nodeId {
-				d.Logger2.Debugf("DHT got reference of self for find_node, id %x", id)
+				d.DebugLogger.Debugf("DHT got reference of self for find_node, id %x", id)
 				continue
 			}
 			if addr == node.address.String() {
@@ -1013,18 +1013,18 @@ func (d *DHT) processFindNodeResults(node *remoteNode, resp responseType) {
 				continue
 			}
 			if existed {
-				d.Logger2.Debugf("DHT: processFindNodeResults DUPE node reference, query %x: %x@%v from %x@%v. Distance: %x.",
+				d.DebugLogger.Debugf("DHT: processFindNodeResults DUPE node reference, query %x: %x@%v from %x@%v. Distance: %x.",
 					query.ih, id, address, node.id, node.address, hashDistance(query.ih, InfoHash(node.id)))
 				totalFindNodeDupes.Add(1)
 			} else {
-				d.Logger2.Debugf("DHT: Got new node reference, query %x: %x@%v from %x@%v. Distance: %x.",
+				d.DebugLogger.Debugf("DHT: Got new node reference, query %x: %x@%v from %x@%v. Distance: %x.",
 					query.ih, id, address, node.id, node.address, hashDistance(query.ih, InfoHash(node.id)))
 				// Includes the node in the routing table and ignores errors.
 				//
 				// Only continue the search if we really have to.
 				r, err := d.routingTable.getOrCreateNode(id, addr, d.config.UDPProto)
 				if err != nil {
-					d.Logger2.Debugf("processFindNodeResults calling getOrCreateNode: %v. Id=%x, Address=%q", err, id, addr)
+					d.DebugLogger.Debugf("processFindNodeResults calling getOrCreateNode: %v. Id=%x, Address=%q", err, id, addr)
 					continue
 				}
 				if d.needMoreNodes() {

--- a/dht.go
+++ b/dht.go
@@ -131,13 +131,23 @@ const (
 // client, such as finding new peers for torrent downloads without requiring a
 // tracker.
 type DHT struct {
+	// PeersRequestResults receives results after user calls PeersRequest method.
+	// Map key contains the 20 bytes infohash string, value contains the list of peer addresses.
+	// Peer addresses are in binary format. You can use DecodePeerAddress function to decode peer addresses.
+	PeersRequestResults chan map[InfoHash][]string
+	// Logger contains hooks for a client to attach for certain RPCs.
+	// Hooks is a better name for the job but we don't want to change it and break existing users.
+	Logger Logger
+	// DebugLogger is called with log messages.
+	// By default, nothing is printed to the output from the library.
+	// If you want to see log messages, you have to provide a DebugLogger implementation.
+	DebugLogger DebugLogger
+
 	nodeId                 string
 	config                 Config
 	routingTable           *routingTable
 	peerStore              *peerStore
 	conn                   *net.UDPConn
-	Logger                 Logger
-	DebugLogger            DebugLogger
 	exploredNeighborhood   bool
 	remoteNodeAcquaintance chan string
 	peersRequest           chan ihReq
@@ -149,9 +159,6 @@ type DHT struct {
 	clientThrottle         *nettools.ClientThrottle
 	store                  *dhtStore
 	tokenSecrets           []string
-
-	// Public channels:
-	PeersRequestResults chan map[InfoHash][]string // key = infohash, v = slice of peers.
 }
 
 // New creates a DHT node. If config is nil, DefaultConfig will be used.

--- a/logging.go
+++ b/logging.go
@@ -1,6 +1,6 @@
 package dht
 
-type Logger2 interface {
+type DebugLogger interface {
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
 	Errorf(format string, args ...interface{})

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,13 @@
+package dht
+
+type Logger2 interface {
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+type nullLogger struct{}
+
+func (l *nullLogger) Debugf(format string, args ...interface{}) {}
+func (l *nullLogger) Infof(format string, args ...interface{})  {}
+func (l *nullLogger) Errorf(format string, args ...interface{}) {}

--- a/neighborhood_test.go
+++ b/neighborhood_test.go
@@ -49,7 +49,10 @@ func TestUpkeep(t *testing.T) {
 		// routing table, but when they are displaced by closer nodes, they
 		// are killed from the neighbors list and from the routing table, so
 		// there should be no sign of them later on.
-		n := randNodeId()
+		n, err := randNodeId()
+		if err != nil {
+			t.Fatal(err)
+		}
 		n[0] = byte(0x3d) // Ensure long distance.
 		r.neighborhoodUpkeep(genremoteNode(string(n)), "udp", newPeerStore(0, 0))
 	}


### PR DESCRIPTION
Ref #61 

@nictuku This is the smallest interface that I can think of: 
https://github.com/cenkalti/dht/blob/29206eba2e98f2d7fab5affe38d5655a78b45db7/logging.go#L3-L7

By implementing this interface people can still use `dht` with `glog` or any logger they want.

I have named it as `Logger2` because there is already an interface named as `Logger`:
https://github.com/cenkalti/dht/blob/29206eba2e98f2d7fab5affe38d5655a78b45db7/dht.go#L223-L227

Of course this name is unacceptable :)

In fact, existing `Logger` interface does not represent a logger actually. I suggest renaming it as `Hooks` or something else and make `Logger2` -> `Logger`. However, this is not possible without breaking backwards compatibility. I think it is best to tag the current commit as `v1` and include this change in `v2`.