### PR TITLE
remove glog completely

### DIFF
--- a/neighborhood_test.go
+++ b/neighborhood_test.go
@@ -39,7 +39,8 @@ func TestCommonBits(t *testing.T) {
 }
 
 func TestUpkeep(t *testing.T) {
-	r := newRoutingTable()
+	var log DebugLogger = &nullLogger{}
+	r := newRoutingTable(&log)
 	r.nodeId = id
 
 	// Current state: 0 neighbors.

--- a/peer_store.go
+++ b/peer_store.go
@@ -3,7 +3,6 @@ package dht
 import (
 	"container/ring"
 
-	log "github.com/golang/glog"
 	"github.com/golang/groupcache/lru"
 )
 
@@ -221,7 +220,6 @@ func (h *peerStore) addLocalDownload(ih InfoHash, port int) {
 }
 
 func (h *peerStore) hasLocalDownload(ih InfoHash) (port int) {
-	port, ok := h.localActiveDownloads[ih]
-	log.V(3).Infof("hasLocalDownload for %x: %v", ih, ok)
-	return port
+	port, _ = h.localActiveDownloads[ih]
+	return
 }

--- a/routing.go
+++ b/routing.go
@@ -1,9 +1,5 @@
 package dht
 
-import (
-	log "github.com/golang/glog"
-)
-
 // DHT routing using a binary tree and no buckets.
 //
 // Nodes have ids of 20-bytes. When looking up an infohash for itself or for a
@@ -213,19 +209,10 @@ func (n *nTree) isOK(ih InfoHash) bool {
 	r := n.value
 
 	if len(r.pendingQueries) > maxNodePendingQueries {
-		log.V(3).Infof("DHT: Skipping because there are too many queries pending for this dude.")
-		log.V(3).Infof("DHT: This shouldn't happen because we should have stopped trying already. Might be a BUG.")
 		return false
 	}
 
-	recent := r.wasContactedRecently(ih)
-	if log.V(4) {
-		log.Infof("wasContactedRecently for ih=%x in node %x@%v returned %v", ih, r.id, r.address, recent)
-	}
-	if recent {
-		return false
-	}
-	return true
+	return !r.wasContactedRecently(ih)
 }
 
 func commonBits(s1, s2 string) int {


### PR DESCRIPTION
I have forgot some to remove some `glog` imports on #62.

This PR removes all remaining `glog` imports and replaces logging calls to recently introduced `DebugLogger`.

I have removed 3 log calls because it was not easy to pass the logger to those functions. They didn't look critical to me. @nictuku  If you want I can try to find an another solution.

To recall the issue; `glog` registers its own flags so they interfere with application's flags when `dht` is used as a library. See:
https://github.com/golang/glog/blob/23def4e6c14b4da8ac2ed8007337bc5eb5007998/glog.go#L398-L404